### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docs-formatter.yml
+++ b/.github/workflows/docs-formatter.yml
@@ -6,6 +6,9 @@ on:
   push:
   workflow_dispatch:
 
+permissions:
+  contents: write
+
 jobs:
   generate-docs:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/gouef/githubtoplanguages/security/code-scanning/4](https://github.com/gouef/githubtoplanguages/security/code-scanning/4)

Add an explicit `permissions` block to `.github/workflows/docs-formatter.yml` so the workflow no longer relies on repository/org defaults and still preserves current behavior (committing and pushing formatted docs).  
The best single fix is to set workflow-level permissions right after the `on:` block:

- `contents: write` (required for `git push` using `GITHUB_TOKEN`)

No imports, methods, or dependencies are needed since this is YAML config only.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
